### PR TITLE
Fix message creation endpoint

### DIFF
--- a/inbox/serializers.py
+++ b/inbox/serializers.py
@@ -1,16 +1,27 @@
 from rest_framework import serializers
+from django.contrib.auth.models import User
 from .models import DirectMessage
 
 
 class DirectMessageSerializer(serializers.ModelSerializer):
-    sender_username    = serializers.ReadOnlyField(source="sender.username")
-    recipient_username = serializers.ReadOnlyField(source="recipient.username")
+    sender_username = serializers.ReadOnlyField(source="sender.username")
+    receiver = serializers.PrimaryKeyRelatedField(
+        source="recipient", queryset=User.objects.all()
+    )
+    receiver_username = serializers.ReadOnlyField(source="recipient.username")
+    content = serializers.CharField(source="body")
 
     class Meta:
-        model  = DirectMessage
+        model = DirectMessage
         fields = [
-            "id", "sender", "sender_username",
-            "recipient", "recipient_username",
-            "subject", "body", "created_at", "read",
+            "id",
+            "sender",
+            "sender_username",
+            "receiver",
+            "receiver_username",
+            "subject",
+            "content",
+            "created_at",
+            "read",
         ]
         read_only_fields = ["sender", "created_at", "read"]

--- a/inbox/urls.py
+++ b/inbox/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
+from rest_framework.routers import DefaultRouter
 from . import views
+
+router = DefaultRouter()
+router.register("messages", views.DirectMessageViewSet, basename="message")
 
 urlpatterns = [
     path("inbox/", views.InboxListCreate.as_view()),
     path("outbox/", views.OutboxList.as_view()),
-    path("messages/<int:pk>/", views.DirectMessageDetail.as_view()),
 ]
+
+urlpatterns += router.urls

--- a/inbox/views.py
+++ b/inbox/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render
+from django.db.models import Q
 
-from rest_framework import generics, permissions
+from rest_framework import generics, permissions, viewsets
 from .models import DirectMessage
 from .serializers import DirectMessageSerializer
 
@@ -43,6 +44,22 @@ class DirectMessageDetail(generics.RetrieveUpdateAPIView):
     def get_queryset(self):
         user = self.request.user
         return DirectMessage.objects.filter(
-            models.Q(sender=user) | models.Q(recipient=user)
+            Q(sender=user) | Q(recipient=user)
         )
+
+
+class DirectMessageViewSet(viewsets.ModelViewSet):
+    """ViewSet providing list, create and retrieve actions for messages."""
+
+    serializer_class = DirectMessageSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        user = self.request.user
+        return DirectMessage.objects.filter(
+            Q(sender=user) | Q(recipient=user)
+        ).order_by("-created_at")
+
+    def perform_create(self, serializer):
+        serializer.save(sender=self.request.user)
 


### PR DESCRIPTION
## Summary
- add DirectMessageViewSet with list and create actions
- register viewset with router for `/messages/`
- update serializer to use `receiver` and `content` fields

## Testing
- `pytest -q` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68400cbc4a1083308249e39a8669026e