### PR TITLE
Use username for DM receiver

### DIFF
--- a/inbox/serializers.py
+++ b/inbox/serializers.py
@@ -5,8 +5,10 @@ from .models import DirectMessage
 
 class DirectMessageSerializer(serializers.ModelSerializer):
     sender_username = serializers.ReadOnlyField(source="sender.username")
-    receiver = serializers.PrimaryKeyRelatedField(
-        source="recipient", queryset=User.objects.all()
+    receiver = serializers.SlugRelatedField(
+        source="recipient",
+        slug_field="username",
+        queryset=User.objects.all(),
     )
     receiver_username = serializers.ReadOnlyField(source="recipient.username")
     content = serializers.CharField(source="body")

--- a/inbox/tests.py
+++ b/inbox/tests.py
@@ -1,3 +1,33 @@
-from django.test import TestCase
+"""
+API tests for the DirectMessage endpoints.
+"""
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from rest_framework.test import APITestCase, APIClient
+from rest_framework import status
+
+
+class DirectMessageAPITests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.sender = User.objects.create_user(
+            username="sender", password="pass123"
+        )
+        self.receiver = User.objects.create_user(
+            username="receiver", password="pass123"
+        )
+        self.inbox_url = "/inbox/"
+
+    def test_create_message_with_username_receiver(self):
+        """Ensure that a direct message can be sent using the receiver's username."""
+        self.client.login(username="sender", password="pass123")
+        data = {
+            "receiver": "receiver",
+            "subject": "Test",
+            "content": "Hello",
+        }
+        response = self.client.post(self.inbox_url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["sender_username"], "sender")
+        self.assertEqual(response.data["receiver"], "receiver")
+        self.assertEqual(response.data["receiver_username"], "receiver")


### PR DESCRIPTION
## Summary
- allow sending direct messages using receiver username
- add API test for creating a direct message with username

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684011d5a9c88330904e90206c919e58