### PR TITLE
Mark messages read when opened

### DIFF
--- a/inbox/serializers.py
+++ b/inbox/serializers.py
@@ -27,3 +27,10 @@ class DirectMessageSerializer(serializers.ModelSerializer):
             "read",
         ]
         read_only_fields = ["sender", "created_at", "read"]
+
+
+class DirectMessageDetailSerializer(DirectMessageSerializer):
+    """Serializer used for retrieving and updating a single message."""
+
+    class Meta(DirectMessageSerializer.Meta):
+        read_only_fields = ["sender", "created_at"]

--- a/inbox/tests.py
+++ b/inbox/tests.py
@@ -31,3 +31,24 @@ class DirectMessageAPITests(APITestCase):
         self.assertEqual(response.data["sender_username"], "sender")
         self.assertEqual(response.data["receiver"], "receiver")
         self.assertEqual(response.data["receiver_username"], "receiver")
+
+    def test_receiver_can_mark_message_as_read(self):
+        """Recipient should be able to mark a message as read."""
+        self.client.login(username="sender", password="pass123")
+        data = {
+            "receiver": "receiver",
+            "subject": "Test",
+            "content": "Hello",
+        }
+        create_resp = self.client.post(self.inbox_url, data, format="json")
+        msg_id = create_resp.data["id"]
+        self.client.logout()
+
+        self.client.login(username="receiver", password="pass123")
+        patch_resp = self.client.patch(
+            f"/messages/{msg_id}/",
+            {"read": True},
+            format="json",
+        )
+        self.assertEqual(patch_resp.status_code, status.HTTP_200_OK)
+        self.assertTrue(patch_resp.data["read"])

--- a/inbox/views.py
+++ b/inbox/views.py
@@ -3,7 +3,10 @@ from django.db.models import Q
 
 from rest_framework import generics, permissions, viewsets
 from .models import DirectMessage
-from .serializers import DirectMessageSerializer
+from .serializers import (
+    DirectMessageSerializer,
+    DirectMessageDetailSerializer,
+)
 
 
 class InboxListCreate(generics.ListCreateAPIView):
@@ -59,6 +62,11 @@ class DirectMessageViewSet(viewsets.ModelViewSet):
         return DirectMessage.objects.filter(
             Q(sender=user) | Q(recipient=user)
         ).order_by("-created_at")
+
+    def get_serializer_class(self):
+        if self.action in ["retrieve", "partial_update", "update"]:
+            return DirectMessageDetailSerializer
+        return DirectMessageSerializer
 
     def perform_create(self, serializer):
         serializer.save(sender=self.request.user)


### PR DESCRIPTION
## Summary
- allow updating `read` via `DirectMessageDetailSerializer`
- use detail serializer for retrieve/update actions
- test marking a message read by the recipient

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68495f6c8e0483308071ba417a3bb52f